### PR TITLE
accept hono/dist/types/hono-base.d.ts

### DIFF
--- a/src/core/generateOpenApiDocs.ts
+++ b/src/core/generateOpenApiDocs.ts
@@ -43,10 +43,12 @@ export function generateOpenApiDocs<OpenAPI extends "3.0" | "3.1" = "3.1">(
 
 function isHono(type: ts.Type) {
   const sourceFile = type.symbol.valueDeclaration!.getSourceFile();
+  const absolutePath = path.resolve(sourceFile.fileName);
   return (
-    path
-      .resolve(sourceFile.fileName)
-      .endsWith(path.join("hono", "dist", "types", "hono.d.ts")) &&
+    (absolutePath.endsWith(
+      path.join("hono", "dist", "types", "hono-base.d.ts"),
+    ) ||
+      absolutePath.endsWith(path.join("hono", "dist", "types", "hono.d.ts"))) &&
     type.symbol.name === "Hono"
   );
 }


### PR DESCRIPTION
not sure why, but my Hono App Type is infered as Hono from `hono/dist/types/hono-base.d.ts`

This PR accept both from hono/dist/types/hono-base.d.ts and hono/dist/types/hono.d.ts